### PR TITLE
fix: don't rely on lifetime UB in Image::load

### DIFF
--- a/src/common/image.hpp
+++ b/src/common/image.hpp
@@ -64,7 +64,8 @@ namespace imglib
 		~Image();
 
 		static inline std::shared_ptr<Image> load(const std::filesystem::path& path) {
-			return load(path.string().c_str());
+			std::string s = path.string();
+			return load(s.c_str());
 		}
 
 		/**


### PR DESCRIPTION
Calling load with path.string().c_str() assumes that the result of path.string() has not been freed by the time execution reaches the location where the result of c_str() is needed, as c_str()'s result's lifetime is tied to the lifetime of the string. The allocator has no reason to not free the string by then though, which results in undefined behaviour.

Fix this by placing the result of path.string() into a local variable, which is kept in memory until the stack frame is left.