### PR TITLE
Feat: More explicative error messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(COMMON_SRC
 		src/common/image.cpp
 		src/common/enums.cpp
 		src/common/pack.cpp
+		src/common/util.cpp
 		src/common/vtftools.cpp)
 
 add_library(com STATIC ${COMMON_SRC})

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -385,7 +385,7 @@ bool ActionConvert::process_file(
 
 	// Convert to desired image format
 	if (vtfFile->GetFormat() != format && !vtfFile->ConvertInPlace(format)) {
-		std::cerr << fmt::format("Could not convert image data to {}\n", formatStr);
+		std::cerr << fmt::format("Could not convert image data to {}: {}\n", formatStr, get_last_vtflib_error());
 		return false;
 	}
 

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -344,7 +344,11 @@ bool ActionConvert::process_file(
 	}
 	// Add standard image data
 	else if (!add_image_data(srcFile, vtfFile.get(), procFormat, true)) {
-		std::cerr << "Could not add image data from file " << srcFile << "\n";
+		if (!std::filesystem::exists(srcFile)) {
+			std::cerr << "Could not open " << srcFile << ", file does not exist\n";
+		} else {
+			std::cerr << "Could not add image data from file " << srcFile << "\n";
+		}
 		return false;
 	}
 
@@ -583,7 +587,8 @@ bool ActionConvert::add_image_data_raw(
 	// This is done here because we don't actually know w/h until now
 	if (create) {
 		if (!file->Init(w, h, 1, 1, 1, format, vlTrue, m_mips)) {
-			std::cerr << "Could not create VTF.\n";
+			// +7 so we do not print `Error:\n`, which destroys the formatting
+			std::cerr << "Could not create VTF: " << LastError.Get() + 7 << "\n";
 			free(dest);
 			return false;
 		}

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -287,6 +287,11 @@ bool ActionConvert::process_file(
 	m_width = opts.get<int>(opts::width);
 	m_height = opts.get<int>(opts::height);
 
+	if (!std::filesystem::exists(srcFile)) {
+		std::cerr << "Could not open " << srcFile << ", file does not exist\n";
+		return false;
+	}
+
 	bool isvtf = srcFile.filename().extension() == ".vtf";
 
 	// If an out file name is not provided, we need to build our own
@@ -344,11 +349,7 @@ bool ActionConvert::process_file(
 	}
 	// Add standard image data
 	else if (!add_image_data(srcFile, vtfFile.get(), procFormat, true)) {
-		if (!std::filesystem::exists(srcFile)) {
-			std::cerr << "Could not open " << srcFile << ", file does not exist\n";
-		} else {
-			std::cerr << "Could not add image data from file " << srcFile << "\n";
-		}
+		std::cerr << "Could not add image data from file " << srcFile << "\n";
 		return false;
 	}
 
@@ -588,7 +589,7 @@ bool ActionConvert::add_image_data_raw(
 	if (create) {
 		if (!file->Init(w, h, 1, 1, 1, format, vlTrue, m_mips)) {
 			// +7 so we do not print `Error:\n`, which destroys the formatting
-			std::cerr << "Could not create VTF: " << LastError.Get() + 7 << "\n";
+			std::cerr << "Could not create VTF: " << vlGetLastError() + 7 << "\n";
 			free(dest);
 			return false;
 		}

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -618,5 +618,5 @@ static const vlChar* get_last_vtflib_error() {
 		return error + 7;
 	}
 
-	return "N/D";
+	return "Unknown error";
 }

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -49,7 +49,6 @@ namespace opts
 } // namespace opts
 
 static bool get_version_from_str(const std::string& str, int& major, int& minor);
-static const vlChar* get_last_vtflib_error();
 
 std::string ActionConvert::get_help() const {
 	return "Convert a generic image file to VTF";
@@ -373,7 +372,7 @@ bool ActionConvert::process_file(
 
 	// Generate thumbnail
 	if (thumbnail && !vtfFile->GenerateThumbnail(srgb)) {
-		std::cerr << fmt::format("Could not generate thumbnail: {}\n", get_last_vtflib_error());
+		std::cerr << fmt::format("Could not generate thumbnail: {}\n", util::get_last_vtflib_error());
 		return false;
 	}
 
@@ -385,13 +384,13 @@ bool ActionConvert::process_file(
 
 	// Convert to desired image format
 	if (vtfFile->GetFormat() != format && !vtfFile->ConvertInPlace(format)) {
-		std::cerr << fmt::format("Could not convert image data to {}: {}\n", formatStr, get_last_vtflib_error());
+		std::cerr << fmt::format("Could not convert image data to {}: {}\n", formatStr, util::get_last_vtflib_error());
 		return false;
 	}
 
 	// Save to disk finally
 	if (!vtfFile->Save(outFile.string().c_str())) {
-		std::cerr << fmt::format("Could not save file {}: {}\n", outFile.string(), get_last_vtflib_error());
+		std::cerr << fmt::format("Could not save file {}: {}\n", outFile.string(), util::get_last_vtflib_error());
 		return false;
 	}
 
@@ -577,7 +576,7 @@ bool ActionConvert::add_image_data_raw(
 		if (!CVTFFile::Convert((vlByte*)data, dest, w, h, dataFormat, format)) {
 			std::cerr << fmt::format(
 				"Could not convert from {} to {}: {}\n", NAMEOF_ENUM(dataFormat), NAMEOF_ENUM(format),
-				get_last_vtflib_error());
+				util::get_last_vtflib_error());
 			free(dest);
 			return false;
 		}
@@ -590,7 +589,7 @@ bool ActionConvert::add_image_data_raw(
 	// This is done here because we don't actually know w/h until now
 	if (create) {
 		if (!file->Init(w, h, 1, 1, 1, format, vlTrue, m_mips)) {
-			std::cerr << "Could not create VTF: " << get_last_vtflib_error() << "\n";
+			std::cerr << "Could not create VTF: " << util::get_last_vtflib_error() << "\n";
 			free(dest);
 			return false;
 		}
@@ -608,15 +607,4 @@ static bool get_version_from_str(const std::string& str, int& major, int& minor)
 	auto majorVer = str.substr(0, pos);
 	auto minorVer = str.substr(pos + 1);
 	return util::strtoint(majorVer, major) && util::strtoint(minorVer, minor);
-}
-
-// Get the last error which occurred in VTFLib
-static const vlChar* get_last_vtflib_error() {
-	auto error = vlGetLastError();
-	if (error) {
-		// +7 so we do not print `Error:\n`, which destroys the formatting
-		return error + 7;
-	}
-
-	return "Unknown error";
 }

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -289,7 +289,7 @@ bool ActionConvert::process_file(
 	m_height = opts.get<int>(opts::height);
 
 	if (!std::filesystem::exists(srcFile)) {
-		std::cerr << "Could not open " << srcFile << ", file does not exist\n";
+		std::cerr << "Could not open " << srcFile << ": file does not exist\n";
 		return false;
 	}
 

--- a/src/cli/action_extract.cpp
+++ b/src/cli/action_extract.cpp
@@ -212,8 +212,8 @@ bool ActionExtract::extract_file(
 
 	if (!ok) {
 		std::cerr << fmt::format(
-			"Could not convert image format '{}' -> '{}'!\n", NAMEOF_ENUM(file_->GetFormat()),
-			destIsFloat ? "RGBA32323232F" : "RGBA8888");
+			"Could not convert image format '{}' -> '{}': {}\n", NAMEOF_ENUM(file_->GetFormat()),
+			destIsFloat ? "RGBA32323232F" : "RGBA8888", util::get_last_vtflib_error());
 		return false;
 	}
 
@@ -249,7 +249,7 @@ bool ActionExtract::load_vtf(const std::filesystem::path& vtfFile) {
 	// Create new file & load it with vtflib
 	file_ = new VTFLib::CVTFFile();
 	if (!file_->Load(buf, numBytes, false)) {
-		std::cerr << fmt::format("Failed to load VTF '{}': {}\n", vtfFile.string(), vlGetLastError());
+		std::cerr << fmt::format("Failed to load VTF '{}': {}\n", vtfFile.string(), util::get_last_vtflib_error());
 		return false;
 	}
 

--- a/src/cli/action_info.cpp
+++ b/src/cli/action_info.cpp
@@ -77,7 +77,7 @@ int ActionInfo::exec(const OptionList& opts) {
 	// Load VTF with vtflib
 	file_ = new VTFLib::CVTFFile();
 	if (!file_->Load(buf, numBytes, false)) {
-		std::cerr << fmt::format(FMT_STRING("Failed to load VTF '{}': {}\n"), file, vlGetLastError());
+		std::cerr << fmt::format(FMT_STRING("Failed to load VTF '{}': {}\n"), file, util::get_last_vtflib_error());
 		return 1;
 	}
 

--- a/src/cli/action_pack.cpp
+++ b/src/cli/action_pack.cpp
@@ -480,7 +480,7 @@ bool ActionPack::save_vtf(
 	initOpts.uiWidth = image->width();
 	initOpts.uiSlices = 1;
 	if (!file_->Init(initOpts)) {
-		std::cerr << fmt::format("Error while saving VTF: {}\n", vlGetLastError());
+		std::cerr << fmt::format("Error while saving VTF: {}\n", util::get_last_vtflib_error());
 		return false; // Cleanup done in cleanup()
 	}
 	file_->SetData(0, 0, 0, 0, image->data<vlByte>());

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -1,0 +1,16 @@
+#include "VTFLib.h"
+
+#include "util.hpp"
+
+namespace util
+{
+	const char* get_last_vtflib_error() {
+		auto error = vlGetLastError();
+		if (error) {
+			// +7 so we do not print `Error:\n`, which destroys the formatting
+			return error + 7;
+		}
+
+		return "Unknown error";
+	}
+} // namespace util

--- a/src/common/util.hpp
+++ b/src/common/util.hpp
@@ -76,4 +76,9 @@ namespace util
 			str[i] = std::tolower(str[i]);
 		return str;
 	}
+
+	/*
+	 * Get the last error which occurred in VTFLib
+	 */
+	const char* get_last_vtflib_error();
 } // namespace util


### PR DESCRIPTION
Makes most CLI error messages also display the VTFLib error that caused them, making understanding what happens way easier.

Closes #41 