### PR TITLE
Various Fixes/Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,10 @@ jobs:
         echo $LD_LIBRARY_PATH
         cmake --build ./build
 
+    - name: Test
+      run: |
+        ctest --test-dir build
+
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v4
       with:
@@ -65,6 +69,10 @@ jobs:
 
     - name: Build
       run: msbuild /m /p:Configuration=Release build\vtex2.sln
+
+    - name: Test
+      run: |
+        ctest --test-dir build
 
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 20)
 
 # Project settings
 option(BUILD_GUI "Build the VTFViewer GUI" ON)
+option(BUILD_TESTS "Build test binaries" OFF)
 
 # Global flags, mainly for UNIX. Use $ORIGIN rpath & -fPIC
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -20,6 +21,20 @@ add_subdirectory(external/vtflib)
 add_subdirectory(external/fmtlib)
 
 add_definitions(-DVTFLIB_STATIC=1)
+
+##############################
+# Setup gtest
+##############################
+if (BUILD_TESTS)
+	include(FetchContent)
+	FetchContent_Declare(
+		googletest
+		GIT_REPOSITORY https://github.com/google/googletest.git
+		GIT_TAG v1.15.2
+	)
+	FetchContent_MakeAvailable(googletest)
+	enable_testing()
+endif()
 
 ##############################
 # Common code
@@ -97,6 +112,36 @@ if (BUILD_GUI)
 		DESTINATION share/icons
 		RENAME vtfview.png
 	)
+endif()
+
+##############################
+# Tests
+##############################
+
+if (BUILD_TESTS)
+	include(GoogleTest)
+
+	add_executable(
+		vtex2_tests
+
+		src/tests/image_tests.cpp
+	)
+
+	target_link_libraries(
+		vtex2_tests PRIVATE
+
+		gtest_main
+		vtflib_static
+		com
+	)
+	
+	target_include_directories(
+		vtex2_tests PRIVATE
+
+		src
+	)
+
+	gtest_discover_tests(vtex2_tests)
 endif()
 
 ##############################

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -319,15 +319,15 @@ bool ActionConvert::process_file(
 			std::max(formatInfo.uiRedBitsPerPixel, formatInfo.uiGreenBitsPerPixel),
 			std::max(formatInfo.uiBlueBitsPerPixel, formatInfo.uiAlphaBitsPerPixel));
 		if (maxBpp > 16) {
-			procChanType = imglib::Float;
+			procChanType = imglib::ChannelType::Float;
 			return IMAGE_FORMAT_RGBA32323232F;
 		}
 		else if (maxBpp > 8) {
-			procChanType = imglib::UInt16;
-			return IMAGE_FORMAT_RGBA16161616F;
+			procChanType = imglib::ChannelType::UInt16;
+			return IMAGE_FORMAT_RGBA16161616;
 		}
 		else {
-			procChanType = imglib::UInt8;
+			procChanType = imglib::ChannelType::UInt8;
 			return IMAGE_FORMAT_RGBA8888;
 		}
 	}();
@@ -519,6 +519,14 @@ bool ActionConvert::add_image_data(
 	if (m_height != -1 && m_width != -1) {
 		if (!image->resize(m_width, m_height))
 			return false;
+	}
+
+	// Hack for VTFLib; Ensure we have an alpha channel because that's well supported in that horrible code
+	if (image->channels() < 4 && image->type() != imglib::ChannelType::UInt8) {
+		if (!image->convert(image->type(), 4)) {
+			std::cerr << fmt::format("Failed to convert {}\n", imageSrc.c_str());
+			return false;
+		}
 	}
 
 	// Add the raw image data

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -303,7 +303,7 @@ bool ActionConvert::process_file(
 		outFile = srcFile.parent_path() / srcFile.filename().replace_extension(".vtf");
 	}
 	else {
-		outFile = srcFile.parent_path() / userOutputFile;
+		outFile = userOutputFile;
 	}
 
 	auto format = ImageFormatFromUserString(formatStr.c_str());

--- a/src/cli/action_extract.cpp
+++ b/src/cli/action_extract.cpp
@@ -217,7 +217,7 @@ bool ActionExtract::extract_file(
 		return false;
 	}
 
-	imglib::Image image(imageData, destIsFloat ? imglib::Float : imglib::UInt8, comps, w, h, true);
+	imglib::Image image(imageData, destIsFloat ? imglib::ChannelType::Float : imglib::ChannelType::UInt8, comps, w, h, true);
 	if (!image.save(outFile.string().c_str(), targetFmt)) {
 		std::cerr << fmt::format("Could not save image to '{}'!\n", outFile.string());
 		return false;

--- a/src/cli/action_extract.cpp
+++ b/src/cli/action_extract.cpp
@@ -24,6 +24,7 @@ namespace opts
 	static int mip;
 	static int recursive;
 	static int noalpha;
+	static int quiet;
 } // namespace opts
 
 std::string ActionExtract::get_help() const {
@@ -82,6 +83,15 @@ const OptionList& ActionExtract::get_options() const {
 				.type(OptType::Bool)
 				.value(false)
 				.help("Exclude alpha channel from converted image"));
+
+		opts::quiet = opts.add(
+			ActionOption()
+				.short_opt("-q")
+				.long_opt("--quiet")
+				.type(OptType::Bool)
+				.value(false)
+				.help("Silence output messages that aren't errors")
+		);
 	};
 	return opts;
 }
@@ -152,7 +162,8 @@ bool ActionExtract::extract_file(
 		outFile = vtfPath.parent_path() / vtfPath.filename().replace_extension(ext);
 	}
 
-	fmt::print("{} -> {}\n", vtfPath.string(), outFile.string());
+	if (!opts.get<bool>(opts::quiet))
+		fmt::print("{} -> {}\n", vtfPath.string(), outFile.string());
 
 	// Validate mipmap selection
 	if (mip > file_->GetMipmapCount()) {

--- a/src/cli/action_pack.cpp
+++ b/src/cli/action_pack.cpp
@@ -130,12 +130,12 @@ const OptionList& ActionPack::get_options() const {
 
 		opts::file = opts.add(
 			ActionOption()
-				.long_opt("--outfile")
+				.long_opt("--output")
 				.short_opt("-o")
 				.type(OptType::String)
 				.value(false)
 				.end_of_line(true)
-				.help("Output file name"));
+				.help("Output file path"));
 
 		opts::rconst = opts.add(
 			ActionOption()

--- a/src/cli/action_pack.cpp
+++ b/src/cli/action_pack.cpp
@@ -322,24 +322,24 @@ bool ActionPack::pack_mrao(
 	pack::ChannelPack_t pack[] = {
 		{.srcChan = 0,
 		 .dstChan = 0,
-		 .srcData = metalnessData->data<uint8_t>(),
-		 .comps = metalnessData->channels(),
+		 .srcData = metalnessData ? metalnessData->data<uint8_t>() : nullptr,
+		 .comps = metalnessData ? metalnessData->channels() : 1,
 		 .constant = mconst},
 		{.srcChan = 0,
 		 .dstChan = 1,
-		 .srcData = roughnessData->data<uint8_t>(),
-		 .comps = roughnessData->channels(),
+		 .srcData = roughnessData ? roughnessData->data<uint8_t>() : nullptr,
+		 .comps = roughnessData ? roughnessData->channels() : 1,
 		 .constant = rconst},
 		{.srcChan = 0,
 		 .dstChan = 2,
-		 .srcData = aoData->data<uint8_t>(),
-		 .comps = aoData->channels(),
+		 .srcData = aoData ? aoData->data<uint8_t>() : nullptr,
+		 .comps = aoData ? aoData->channels() : 1,
 		 .constant = aoconst},
 		{
 			.srcChan = 0,
 			.dstChan = 3,
-			.srcData = tmaskData->data<uint8_t>(),
-			.comps = tmaskData->channels(),
+			.srcData = tmaskData ? tmaskData->data<uint8_t>() : nullptr,
+			.comps = tmaskData ? tmaskData->channels() : 1,
 			.constant = 1,
 		}};
 
@@ -355,9 +355,14 @@ bool ActionPack::pack_mrao(
 	}
 
 	// Free up some mem
-	roughnessData->clear();
-	aoData->clear();
-	metalnessData->clear();
+	if (roughnessData)
+		roughnessData->clear();
+	if (aoData)
+		aoData->clear();
+	if (metalnessData)
+		metalnessData->clear();
+	if (tmaskData)
+		tmaskData->clear();
 
 	// If user requested clamp, do that now
 	if (clampw > 0 || clamph > 0) {
@@ -373,7 +378,8 @@ bool ActionPack::pack_mrao(
 
 	bool success = true;
 	if ((success = save_vtf(outpath, outImage, opts, false)))
-		std::cout << fmt::format("Finished processing {}\n", outpath.string());
+		if (!opts.get<bool>(opts::quiet))
+			std::cout << fmt::format("Finished {} ({} KiB)\n", outpath.string(), file_->GetSize() / 1024);
 	return success;
 }
 

--- a/src/cli/action_pack.cpp
+++ b/src/cli/action_pack.cpp
@@ -30,6 +30,7 @@ namespace opts
 	static int width, height, mips;
 	static int mconst, rconst, aoconst, hconst;
 	static int toDX;
+	static int quiet;
 } // namespace opts
 
 std::string ActionPack::get_help() const {
@@ -176,6 +177,15 @@ const OptionList& ActionPack::get_options() const {
 				.value(false)
 				.type(OptType::Bool)
 				.help("Treat the incoming normal map as a OpenGL normal map"));
+
+		opts::quiet = opts.add(
+			ActionOption()
+				.long_opt("--quiet")
+				.short_opt("-q")
+				.value(false)
+				.type(OptType::Bool)
+				.help("Silence output messages that aren't errors")
+		);
 	};
 	return opts;
 }
@@ -467,8 +477,8 @@ bool ActionPack::pack_normal(
 
 	success = save_vtf(outpath, outImage, opts, true);
 
-	if (success)
-		std::cout << fmt::format("Finished processing {}\n", outpath.string());
+	if (success && !opts.get<bool>(opts::quiet))
+		std::cout << fmt::format("Finished {} ({} KiB)\n", outpath.string(), file_->GetSize() / 1024);
 	return success;
 }
 

--- a/src/common/lwiconv.hpp
+++ b/src/common/lwiconv.hpp
@@ -1,0 +1,141 @@
+/**
+ * lwiconv: Lightweight Image Conversion library.
+ * Not designed to be particularly fast, just simple.
+ */
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace lwiconv
+{
+constexpr int MAX_CHANNELS = 4;
+
+/**
+ * Just represents a pixel. Assumed to be normalized unsigned float format [0-1]
+ */
+struct PixelF {
+	float d[MAX_CHANNELS];
+};
+
+namespace detail {
+
+template <typename T>
+inline float tofloat(const T& t);
+
+template<> inline float tofloat<uint8_t>(const uint8_t& t) {
+	return float(t) / float(UINT8_MAX);
+}
+
+template<> inline float tofloat<uint16_t>(const uint16_t& t) {
+	return float(t) / float(UINT16_MAX);
+}
+
+template<> inline float tofloat<float>(const float& t) {
+	return t;
+}
+
+template <typename T>
+inline T fromfloat(float p);
+
+template<> inline uint8_t fromfloat<uint8_t>(float p) {
+	return uint8_t(p * UINT8_MAX);
+}
+
+template<> inline uint16_t fromfloat<uint16_t>(float p) {
+	return uint16_t(p * UINT16_MAX);
+}
+
+template<> inline float fromfloat<float>(float p) {
+	return p;
+}
+
+template <typename T, int COMPS>
+inline PixelF pixel_from_data(const T* pin, const PixelF& defs) {
+	if constexpr (COMPS == 1)
+		return {{tofloat(*pin), defs.d[1], defs.d[2], defs.d[3]}};
+	else if constexpr (COMPS == 2)
+		return {{tofloat(*pin), tofloat(pin[1]), defs.d[2], defs.d[3]}};
+	else if constexpr (COMPS == 3)
+		return {{tofloat(*pin), tofloat(pin[1]), tofloat(pin[2]), defs.d[3]}};
+	else if constexpr (COMPS == 4)
+		return {{tofloat(*pin), tofloat(pin[1]), tofloat(pin[2]), tofloat(pin[3])}};
+}
+
+template <typename T, int COMPS>
+inline void pixel_to_data(T* pout, const PixelF& p) {
+	static_assert(COMPS <= MAX_CHANNELS && COMPS > 0);
+	if constexpr (COMPS == 1) {
+		pout[0] = fromfloat<T>(p.d[0]);
+	}
+	else if constexpr (COMPS == 2) {
+		pout[0] = fromfloat<T>(p.d[0]);
+		pout[1] = fromfloat<T>(p.d[1]);
+	}
+	else if constexpr (COMPS == 3) {
+		pout[0] = fromfloat<T>(p.d[0]);
+		pout[1] = fromfloat<T>(p.d[1]);
+		pout[2] = fromfloat<T>(p.d[2]);
+	}
+	else if constexpr (COMPS == 4) {
+		pout[0] = fromfloat<T>(p.d[0]);
+		pout[1] = fromfloat<T>(p.d[1]);
+		pout[2] = fromfloat<T>(p.d[2]);
+		pout[3] = fromfloat<T>(p.d[3]);
+	}
+}
+
+}
+
+/**
+ * \brief Convert buffer from one color format to another
+ * The input and output buffers are assumed to be the same dimensions.
+ * \param in Pointer to the input buffer
+ * \param out Pointer to the output buffer
+ * \param w Width of the image
+ * \param h Height of the image
+ * \param inC Number of input channels
+ * \param outC Number of output channels
+ * \param inStride Input stride, in bytes. If set <= 0, it will be computed for you based on inC 
+ * \param outStride Output stride, in bytes. If set <= 0, it will be computed for you based on outC
+ * \param channelDefaults If inC < outC, the missing channel data from each input pixel will be defaulted to this. For example, if you're converting from
+ *  an RGB_888 -> RGBA_8888 image, supplying {0,0,0,1} here will default the resulting alpha channel to 255
+ */
+template <typename Tin, typename Tout>
+static void convert_generic(const void* in, void* out, int w, int h, int inC, int outC, int inStride = -1, int outStride = -1, const PixelF& channelDefaults = {0,0,0,0}) {
+	const Tin* pin = static_cast<const Tin*>(in);
+	Tout* pout = static_cast<Tout*>(out);
+
+	// Compute stride if not provided
+	if (inStride <= 0)
+		inStride = inC * sizeof(Tin);
+	if (outStride <= 0)
+		outStride = outC * sizeof(Tout);
+
+	using fnInConv = PixelF (*)(const Tin*, const PixelF&);
+	constexpr fnInConv inConvFuncs[MAX_CHANNELS] = {
+		detail::pixel_from_data<Tin, 1>,
+		detail::pixel_from_data<Tin, 2>,
+		detail::pixel_from_data<Tin, 3>,
+		detail::pixel_from_data<Tin, 4>,
+	};
+	const fnInConv inConv = inConvFuncs[inC-1];
+
+	using fnOutConv = void (*)(Tout*, const PixelF&);
+	constexpr fnOutConv outConvFuncs[MAX_CHANNELS] = {
+		detail::pixel_to_data<Tout, 1>,
+		detail::pixel_to_data<Tout, 2>,
+		detail::pixel_to_data<Tout, 3>,
+		detail::pixel_to_data<Tout, 4>,
+	};
+	const fnOutConv outConv = outConvFuncs[outC-1];
+
+	const size_t target = w * h;
+	const size_t isb = inStride / sizeof(Tin);
+	const size_t osb = outStride / sizeof(Tout);
+
+	for (size_t i = 0; i < target; ++i, pin += isb, pout += osb)
+		outConv(pout, inConv(pin, channelDefaults));
+}
+
+} // lwiconv

--- a/src/common/pack.cpp
+++ b/src/common/pack.cpp
@@ -56,7 +56,7 @@ pack::pack_image(int destChannels, ChannelPack_t* channels, int numChannels, int
 	}
 
 	// Allocate image
-	std::shared_ptr<imglib::Image> result = std::make_shared<imglib::Image>(imglib::UInt8, destChannels, w, h, false);
+	std::shared_ptr<imglib::Image> result = std::make_shared<imglib::Image>(imglib::ChannelType::UInt8, destChannels, w, h, false);
 
 	if (numChannels == 1)
 		pack_channel<1>(result->data<uint8_t>(), destChannels, channels, w, h);

--- a/src/tests/image_tests.cpp
+++ b/src/tests/image_tests.cpp
@@ -1,0 +1,120 @@
+
+#include <cstdint>
+#include <cstddef>
+#include <climits>
+
+#include "gtest/gtest.h"
+
+#include "common/lwiconv.hpp"
+
+using namespace lwiconv;
+
+template<typename T>
+static void fillPattern(T* buf, const T (&pattern)[MAX_CHANNELS], int w, int h, int channels) {
+	for (int i = 0; i < w * h; ++i) {
+		for (int j = 0; j < channels; ++j)
+			buf[i * channels + j] = pattern[j];
+	}
+}
+
+template<typename T>
+struct Buffer {
+	T* data;
+	int w, h, c;
+	Buffer(int w, int h, int channels) {
+		data = (T*)malloc(w * h * channels * sizeof(T));
+		this->w = w;
+		this->h = h;
+		this->c = channels;
+	}
+
+	~Buffer() {
+		free(data);
+	}
+
+	void fill(const T(&pattern)[MAX_CHANNELS]) {
+		fillPattern<T>((T*)data, pattern, w, h, c);
+	}
+
+	void check(const T(&pattern)[MAX_CHANNELS]) {
+		for (int i = 0; i < w * h; ++i) {
+			for (int j = 0; j < c; ++j) {
+				if (data[i*c+j] != pattern[j])
+					abort();
+				ASSERT_EQ(data[i*c+j], pattern[j]);
+			}
+		}
+	}
+};
+
+template<typename Tin, typename Tout>
+void runTest(int width, int height, int inChannels, int outChannels, const Tin (&ipattern)[MAX_CHANNELS], const Tout (&opattern)[MAX_CHANNELS], int inBufChannels = -1, int inStride = -1, int outStride = -1,
+	const PixelF& channelDefaults = {0,0,0,1})
+{
+	Buffer<Tin> b(width, height, inBufChannels < 0 ? inChannels : inBufChannels);
+	b.fill(ipattern);
+
+	Buffer<Tout> o(width, height, outChannels);
+
+	convert_generic<Tin, Tout>(b.data, o.data, width, height, inChannels, outChannels, inStride, outStride, channelDefaults);
+
+	o.check(opattern);
+}
+
+TEST(ImageTests, Basic8To16)
+{
+	runTest<uint8_t, uint16_t>(32, 32, 4, 4, {0xFF, 0, 0xFF, 0}, {0xFFFF, 0, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(32, 16, 4, 4, {0xFF, 0, 0xFF, 0}, {0xFFFF, 0, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(32, 128, 4, 4, {0xFF, 0, 0xFF, 0}, {0xFFFF, 0, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(32, 7, 4, 4, {0xFF, 0, 0xFF, 0}, {0xFFFF, 0, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(2, 7, 4, 4, {0, 0xFF, 0xFF, 0}, {0, 0xFFFF, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(2, 1, 4, 4, {0, 0, 0xFF, 0}, {0, 0, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(45, 177, 4, 4, {0xFF, 0, 0xFF, 0}, {0xFFFF, 0, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(1024, 999, 4, 4, {0xFF, 0, 0xFF, 0}, {0xFFFF, 0, 0xFFFF, 0});
+}
+
+TEST(ImageTests, DiffChannels8To16)
+{
+	runTest<uint8_t, uint16_t>(32,	32, 4, 4, 	{0xFF, 	0, 		0xFF, 0}, 	{0xFFFF, 	0, 		0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(32,	16,	4, 4, 	{0xFF, 	0, 		0xFF, 0}, 	{0xFFFF, 	0, 		0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(32,	128,4, 3, 	{0xFF, 	0, 		0xFF, 0}, 	{0xFFFF, 	0, 		0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(32,	7, 	4, 2, 	{0xFF, 	0, 		0xFF, 0}, 	{0xFFFF, 	0, 		0,		0});
+	runTest<uint8_t, uint16_t>(2,	7, 	4, 3, 	{0, 	0xFF, 	0xFF, 0xFF},{0, 		0xFFFF, 0xFFFF, 0});
+	runTest<uint8_t, uint16_t>(2, 	1, 	2, 4, 	{0, 	0, 		0xFF, 0}, 	{0, 		0, 		0,		0xFFFF},	4, sizeof(uint8_t) * 4, -1, {0, 0, 0, 1.f});
+	runTest<uint8_t, uint16_t>(45, 177, 3, 4, 	{0xFF, 	0, 		0xFF, 0}, 	{0xFFFF,	0, 		0xFFFF, 0xFFFF},	4, sizeof(uint8_t) * 4, -1, {0, 0, 0, 1.f});
+	runTest<uint8_t, uint16_t>(1024, 999, 2, 2, {0xFF, 	0, 		0xFF, 0}, 	{0xFFFF,	0, 		0,		0});
+}
+
+TEST(ImageTests, Basic8To32)
+{
+	runTest<uint8_t, float>(32, 32, 4, 4, {0xFF, 0, 0xFF, 0}, {1.0f, 0, 1.0f, 0});
+	runTest<uint8_t, float>(32, 32, 4, 4, {0xFF, 0, 128, 0}, {1.0f, 0, 128.f / 255.f, 0});
+}
+
+TEST(ImageTests, Basic32To16)
+{
+	runTest<float, uint16_t>(32, 32, 4, 4, {1.0f, 0, 1.0f, 0}, {0xFFFF, 0, 0xFFFF, 0});
+	runTest<float, uint16_t>(5, 32, 4, 4, {1.0f, 0, 1.0f, 0}, {0xFFFF, 0, 0xFFFF, 0});
+	runTest<float, uint16_t>(55, 55, 4, 4, {1.0f, 0.5f, 1.0f, 0}, {0xFFFF, uint16_t(0.5f * 0xFFFF), 0xFFFF, 0});
+}
+
+TEST(ImageTests, Basic32To8)
+{
+	runTest<float, uint8_t>(32, 32, 4, 4, {1.0f, 0, 1.0f, 0}, {0xFF, 0, 0xFF, 0});
+	runTest<float, uint8_t>(5, 32, 4, 4, {1.0f, 0, 1.0f, 0}, {0xFF, 0, 0xFF, 0});
+	runTest<float, uint8_t>(55, 55, 4, 4, {1.0f, 0.5f, 1.0f, 0}, {0xFF, uint16_t(0.5f * 0xFF), 0xFF, 0});
+}
+
+TEST(ImageTests, DiffChannels32To8)
+{
+	runTest<float, uint8_t>(32,	32, 2, 4, 	{0, 	0, 		0,	0}, 	{0, 	0, 		0xFF,	0xFF}, 4, sizeof(uint8_t) * 4, -1, {0, 0, 1.f, 1.f});
+	runTest<float, uint8_t>(32,	32, 3, 4, 	{0, 	0, 		0,	0}, 	{0, 	0, 		0,		0xFF}, 4, sizeof(uint8_t) * 4, -1, {0, 0, 1.f, 1.f});
+	runTest<float, uint8_t>(3200,	3200, 1, 4, 	{0, 	0, 		0,	0}, 	{0, 	0xFF, 	0,		0xFF}, 4, sizeof(uint8_t) * 4, -1, {0, 1.f, 0, 1.f});
+}
+
+TEST(ImageTests, Basic8To8)
+{
+	runTest<uint8_t, uint8_t>(32, 32, 4, 4, {0xFF, 0, 0xFF, 0}, {0xFF, 0, 0xFF, 0});
+	runTest<uint8_t, uint8_t>(32, 32, 4, 4, {128, 0, 0xFF, 99}, {128, 0, 0xFF, 99});
+}
+


### PR DESCRIPTION
* Fix 16-bit PNG handling
* Rewrote image conversion
* Added tests for image conversion
* Added -q/--quiet options for pack/convert/extract
* Renamed `pack`'s `--outfile` arg to `--output` to match other actions
* Make convert's `-o`/`--output` a path rather than just file name

vtflib sucks