### PR TITLE
Fix CMake configuration error when BUILD_GUI is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,11 @@ if (BUILD_GUI)
 			res/resource.qrc)
 
 	add_executable(vtfview ${VIEWER_SRC})
-endif ()
 
-# Set up the debugger so it can run the program without copying a million dlls
-if (WIN32)
-	set_target_properties(vtfview PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=%PATH%;${QT_BASEDIR}/bin;")
+	 # Set up the debugger so it can run the program without copying a million dlls
+	if (WIN32)
+		set_target_properties(vtfview PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=%PATH%;${QT_BASEDIR}/bin;")
+	endif ()
 endif ()
 
 target_link_libraries(vtex2 PRIVATE vtflib_static com fmt::fmt)


### PR DESCRIPTION
Attempting to call `Set_Target_Properties` on the non-existent `vtfview` target results in the following error:

```
CMake Error at CMakeLists.txt:83 (set_target_properties):
  set_target_properties Can not find target to add properties to: vtfview
```