### PR TITLE
Swizzle option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ target_link_libraries(vtex2 PRIVATE vtflib_static com fmt::fmt)
 target_include_directories(vtex2 PRIVATE src external)
 target_include_directories(com PRIVATE src external external/vtflib/lib)
 
+if (UNIX)
+	# Don't build vtex2 cli as a dynamic executable
+	set_target_properties(vtex2 PROPERTIES LINK_FLAGS "-static-libgcc -static-libstdc++ -static")
+endif()
+
 if (BUILD_GUI)
 	target_link_libraries(vtfview PRIVATE vtflib_static com fmt::fmt)
 	target_include_directories(vtfview PRIVATE src external)

--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -429,7 +429,7 @@ uint32_t imglib::swizzle_from_str(const char* str) {
 		case 'a': v = 3; break;
 		default: return 0xFFFFFFFF;
 		}
-		mask |= v << (i*8);
+		mask |= v << ((lwiconv::MAX_CHANNELS-i-1)*8);
 	}
 	return mask;
 }

--- a/src/common/image.hpp
+++ b/src/common/image.hpp
@@ -14,6 +14,8 @@ namespace imglib
 {
 
 	constexpr int MAX_CHANNELS = 4;
+	
+	using lwiconv::make_swizzle;
 
 	/**
 	 * Per-channel data type
@@ -48,6 +50,9 @@ namespace imglib
 
 	using ProcFlags = uint32_t;
 	inline constexpr ProcFlags PROC_GL_TO_DX_NORM = (1 << 0);
+	inline constexpr ProcFlags PROC_INVERT_ALPHA = (1 << 1);
+	
+	uint32_t swizzle_from_str(const char* str);
 
 	/**
 	 * Returns the number of bytes per pixel for the format
@@ -124,6 +129,12 @@ namespace imglib
 		 * @param pdef Default pixel fill for uninitialized pixels
 		 */
 		bool convert(ChannelType type, int channels = -1, const lwiconv::PixelF& pdef = {0,0,0,1});
+		
+		/**
+		 * Perform in-place swizzle of components
+		 * @param mask Swizzle mask. @see lwiconv::make_swizzle
+		 */
+		bool swizzle(uint32_t mask);
 
 		/**
 		 * Returns the VTF format which matches up to the data we have internally here

--- a/src/tests/image_tests.cpp
+++ b/src/tests/image_tests.cpp
@@ -118,3 +118,12 @@ TEST(ImageTests, Basic8To8)
 	runTest<uint8_t, uint8_t>(32, 32, 4, 4, {128, 0, 0xFF, 99}, {128, 0, 0xFF, 99});
 }
 
+TEST(ImageTests, BasicSwizzle)
+{
+	uint8_t img[4] = {1,2,3,4};
+	ASSERT_TRUE(swizzle<uint8_t>(img, 1, 1, 4, make_swizzle(3, 2, 1, 0)));
+	ASSERT_EQ(img[0], 4);
+	ASSERT_EQ(img[1], 3);
+	ASSERT_EQ(img[2], 2);
+	ASSERT_EQ(img[3], 1);
+}


### PR DESCRIPTION
I don't know why I did this. I was going to implement alpha inversion for MRAO maps (to fix the $blendtintbymraoalpha thing), but for some reason that meant "swizzle" in my tired brain.

Also I didn't test any of this, except for that one unit test case.