### PR TITLE
Force v7.6 if using BC7 format

### DIFF
--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -496,7 +496,7 @@ bool ActionConvert::set_properties(VTFLib::CVTFFile* vtfFile) {
 			return false;
 		}
 
-		minorVer = (compressionLevel > 0) ? 6 : minorVer; // Force 7.6 if using DEFLATE
+		minorVer = (compressionLevel > 0 || vtfFile->GetFormat() == IMAGE_FORMAT_BC7) ? 6 : minorVer; // Force 7.6 if using DEFLATE or a Strata-specific image format
 		vtfFile->SetVersion(majorVer, minorVer);
 	}
 

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -296,7 +296,6 @@ bool ActionConvert::process_file(
 	const auto formatStr = opts.get<std::string>(opts::format);
 	const auto srgb = opts.get<bool>(opts::srgb);
 	const auto thumbnail = opts.get<bool>(opts::thumbnail);
-	const auto verStr = opts.get<std::string>(opts::version);
 	const auto isNormal = opts.get<bool>(opts::normal);
 
 	auto nomips = opts.get<bool>(opts::nomips);
@@ -340,14 +339,13 @@ bool ActionConvert::process_file(
 			procChanType = imglib::ChannelType::Float;
 			return IMAGE_FORMAT_RGBA32323232F;
 		}
-		else if (maxBpp > 8) {
+		if (maxBpp > 8) {
 			procChanType = imglib::ChannelType::UInt16;
 			return IMAGE_FORMAT_RGBA16161616;
 		}
-		else {
-			procChanType = imglib::ChannelType::UInt8;
-			return IMAGE_FORMAT_RGBA8888;
-		}
+		// maxBpp <= 8
+		procChanType = imglib::ChannelType::UInt8;
+		return IMAGE_FORMAT_RGBA8888;
 	}();
 
 	// If we're processing a VTF, let's add that VTF image data

--- a/src/common/enums.cpp
+++ b/src/common/enums.cpp
@@ -9,158 +9,157 @@
 VTFImageFormat ImageFormatFromString(const char* arg) {
 	if (str::strcasecmp("IMAGE_FORMAT_RGBA8888", arg) == 0)
 		return IMAGE_FORMAT_RGBA8888;
-	else if (str::strcasecmp("IMAGE_FORMAT_ABGR8888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_ABGR8888", arg) == 0)
 		return IMAGE_FORMAT_ABGR8888;
-	else if (str::strcasecmp("IMAGE_FORMAT_RGB888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_RGB888", arg) == 0)
 		return IMAGE_FORMAT_RGB888;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGR888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGR888", arg) == 0)
 		return IMAGE_FORMAT_BGR888;
-	else if (str::strcasecmp("IMAGE_FORMAT_RGB565", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_RGB565", arg) == 0)
 		return IMAGE_FORMAT_RGB565;
-	else if (str::strcasecmp("IMAGE_FORMAT_I8", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_I8", arg) == 0)
 		return IMAGE_FORMAT_I8;
-	else if (str::strcasecmp("IMAGE_FORMAT_IA88", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_IA88", arg) == 0)
 		return IMAGE_FORMAT_IA88;
-	else if (str::strcasecmp("IMAGE_FORMAT_P8", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_P8", arg) == 0)
 		return IMAGE_FORMAT_P8;
-	else if (str::strcasecmp("IMAGE_FORMAT_A8", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_A8", arg) == 0)
 		return IMAGE_FORMAT_A8;
-	else if (str::strcasecmp("IMAGE_FORMAT_RGB888_BLUESCREEN", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_RGB888_BLUESCREEN", arg) == 0)
 		return IMAGE_FORMAT_RGB888_BLUESCREEN;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGR888_BLUESCREEN", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGR888_BLUESCREEN", arg) == 0)
 		return IMAGE_FORMAT_BGR888_BLUESCREEN;
-	else if (str::strcasecmp("IMAGE_FORMAT_ARGB8888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_ARGB8888", arg) == 0)
 		return IMAGE_FORMAT_ARGB8888;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGRA8888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGRA8888", arg) == 0)
 		return IMAGE_FORMAT_BGRA8888;
-	else if (str::strcasecmp("IMAGE_FORMAT_DXT1", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_DXT1", arg) == 0)
 		return IMAGE_FORMAT_DXT1;
-	else if (str::strcasecmp("IMAGE_FORMAT_DXT3", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_DXT3", arg) == 0)
 		return IMAGE_FORMAT_DXT3;
-	else if (str::strcasecmp("IMAGE_FORMAT_DXT5", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_DXT5", arg) == 0)
 		return IMAGE_FORMAT_DXT5;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGRX8888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGRX8888", arg) == 0)
 		return IMAGE_FORMAT_BGRX8888;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGR565", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGR565", arg) == 0)
 		return IMAGE_FORMAT_BGR565;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGRX5551", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGRX5551", arg) == 0)
 		return IMAGE_FORMAT_BGRX5551;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGRA4444", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGRA4444", arg) == 0)
 		return IMAGE_FORMAT_BGRA4444;
-	else if (str::strcasecmp("IMAGE_FORMAT_DXT1_ONEBITALPHA", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_DXT1_ONEBITALPHA", arg) == 0)
 		return IMAGE_FORMAT_DXT1_ONEBITALPHA;
-	else if (str::strcasecmp("IMAGE_FORMAT_BGRA5551", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BGRA5551", arg) == 0)
 		return IMAGE_FORMAT_BGRA5551;
-	else if (str::strcasecmp("IMAGE_FORMAT_UV88", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_UV88", arg) == 0)
 		return IMAGE_FORMAT_UV88;
-	else if (str::strcasecmp("IMAGE_FORMAT_UVWQ8888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_UVWQ8888", arg) == 0)
 		return IMAGE_FORMAT_UVWQ8888;
-	else if (str::strcasecmp("IMAGE_FORMAT_RGBA16161616F", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_RGBA16161616F", arg) == 0)
 		return IMAGE_FORMAT_RGBA16161616F;
-	else if (str::strcasecmp("IMAGE_FORMAT_RGBA16161616", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_RGBA16161616", arg) == 0)
 		return IMAGE_FORMAT_RGBA16161616;
-	else if (str::strcasecmp("IMAGE_FORMAT_UVLX8888", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_UVLX8888", arg) == 0)
 		return IMAGE_FORMAT_UVLX8888;
-	else if (str::strcasecmp("IMAGE_FORMAT_R32F", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_R32F", arg) == 0)
 		return IMAGE_FORMAT_R32F;
-	else if (str::strcasecmp("IMAGE_FORMAT_RGB323232F", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_RGB323232F", arg) == 0)
 		return IMAGE_FORMAT_RGB323232F;
-	else if (str::strcasecmp("IMAGE_FORMAT_RGBA32323232F", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_RGBA32323232F", arg) == 0)
 		return IMAGE_FORMAT_RGBA32323232F;
-	else if (str::strcasecmp("IMAGE_FORMAT_NV_NULL", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_NV_NULL", arg) == 0)
 		return IMAGE_FORMAT_NV_NULL;
-	else if (str::strcasecmp("IMAGE_FORMAT_ATI2N", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_ATI2N", arg) == 0)
 		return IMAGE_FORMAT_ATI2N;
-	else if (str::strcasecmp("IMAGE_FORMAT_ATI1N", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_ATI1N", arg) == 0)
 		return IMAGE_FORMAT_ATI1N;
-	else if (str::strcasecmp("IMAGE_FORMAT_BC7", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_BC7", arg) == 0)
 		return IMAGE_FORMAT_BC7;
-	else if (str::strcasecmp("IMAGE_FORMAT_COUNT", arg) == 0)
+	if (str::strcasecmp("IMAGE_FORMAT_COUNT", arg) == 0)
 		return IMAGE_FORMAT_COUNT;
-	else
-		return IMAGE_FORMAT_NONE;
+	return IMAGE_FORMAT_NONE;
 }
 
 std::vector<std::string> TextureFlagsToStringVector(std::uint32_t flags) {
 	std::vector<std::string> ret;
 	if (flags & TEXTUREFLAGS_POINTSAMPLE)
-		ret.push_back("TEXTUREFLAGS_POINTSAMPLE");
+		ret.emplace_back("TEXTUREFLAGS_POINTSAMPLE");
 	if (flags & TEXTUREFLAGS_TRILINEAR)
-		ret.push_back("TEXTUREFLAGS_TRILINEAR");
+		ret.emplace_back("TEXTUREFLAGS_TRILINEAR");
 	if (flags & TEXTUREFLAGS_CLAMPS)
-		ret.push_back("TEXTUREFLAGS_CLAMPS");
+		ret.emplace_back("TEXTUREFLAGS_CLAMPS");
 	if (flags & TEXTUREFLAGS_CLAMPT)
-		ret.push_back("TEXTUREFLAGS_CLAMPT");
+		ret.emplace_back("TEXTUREFLAGS_CLAMPT");
 	if (flags & TEXTUREFLAGS_ANISOTROPIC)
-		ret.push_back("TEXTUREFLAGS_ANISOTROPIC");
+		ret.emplace_back("TEXTUREFLAGS_ANISOTROPIC");
 	if (flags & TEXTUREFLAGS_HINT_DXT5)
-		ret.push_back("TEXTUREFLAGS_HINT_DXT5");
+		ret.emplace_back("TEXTUREFLAGS_HINT_DXT5");
 	if (flags & TEXTUREFLAGS_SRGB)
-		ret.push_back("TEXTUREFLAGS_SRGB");
+		ret.emplace_back("TEXTUREFLAGS_SRGB");
 	if (flags & TEXTUREFLAGS_DEPRECATED_NOCOMPRESS)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_NOCOMPRESS");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_NOCOMPRESS");
 	if (flags & TEXTUREFLAGS_NORMAL)
-		ret.push_back("TEXTUREFLAGS_NORMAL");
+		ret.emplace_back("TEXTUREFLAGS_NORMAL");
 	if (flags & TEXTUREFLAGS_NOMIP)
-		ret.push_back("TEXTUREFLAGS_NOMIP");
+		ret.emplace_back("TEXTUREFLAGS_NOMIP");
 	if (flags & TEXTUREFLAGS_NOLOD)
-		ret.push_back("TEXTUREFLAGS_NOLOD");
+		ret.emplace_back("TEXTUREFLAGS_NOLOD");
 	if (flags & TEXTUREFLAGS_MINMIP)
-		ret.push_back("TEXTUREFLAGS_MINMIP");
+		ret.emplace_back("TEXTUREFLAGS_MINMIP");
 	if (flags & TEXTUREFLAGS_PROCEDURAL)
-		ret.push_back("TEXTUREFLAGS_PROCEDURAL");
+		ret.emplace_back("TEXTUREFLAGS_PROCEDURAL");
 	if (flags & TEXTUREFLAGS_ONEBITALPHA)
-		ret.push_back("TEXTUREFLAGS_ONEBITALPHA");
+		ret.emplace_back("TEXTUREFLAGS_ONEBITALPHA");
 	if (flags & TEXTUREFLAGS_EIGHTBITALPHA)
-		ret.push_back("TEXTUREFLAGS_EIGHTBITALPHA");
+		ret.emplace_back("TEXTUREFLAGS_EIGHTBITALPHA");
 	if (flags & TEXTUREFLAGS_ENVMAP)
-		ret.push_back("TEXTUREFLAGS_ENVMAP");
+		ret.emplace_back("TEXTUREFLAGS_ENVMAP");
 	if (flags & TEXTUREFLAGS_RENDERTARGET)
-		ret.push_back("TEXTUREFLAGS_RENDERTARGET");
+		ret.emplace_back("TEXTUREFLAGS_RENDERTARGET");
 	if (flags & TEXTUREFLAGS_DEPTHRENDERTARGET)
-		ret.push_back("TEXTUREFLAGS_DEPTHRENDERTARGET");
+		ret.emplace_back("TEXTUREFLAGS_DEPTHRENDERTARGET");
 	if (flags & TEXTUREFLAGS_NODEBUGOVERRIDE)
-		ret.push_back("TEXTUREFLAGS_NODEBUGOVERRIDE");
+		ret.emplace_back("TEXTUREFLAGS_NODEBUGOVERRIDE");
 	if (flags & TEXTUREFLAGS_SINGLECOPY)
-		ret.push_back("TEXTUREFLAGS_SINGLECOPY");
+		ret.emplace_back("TEXTUREFLAGS_SINGLECOPY");
 	if (flags & TEXTUREFLAGS_UNUSED0)
-		ret.push_back("TEXTUREFLAGS_UNUSED0");
+		ret.emplace_back("TEXTUREFLAGS_UNUSED0");
 	if (flags & TEXTUREFLAGS_DEPRECATED_ONEOVERMIPLEVELINALPHA)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_ONEOVERMIPLEVELINALPHA");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_ONEOVERMIPLEVELINALPHA");
 	if (flags & TEXTUREFLAGS_UNUSED1)
-		ret.push_back("TEXTUREFLAGS_UNUSED1");
+		ret.emplace_back("TEXTUREFLAGS_UNUSED1");
 	if (flags & TEXTUREFLAGS_DEPRECATED_PREMULTCOLORBYONEOVERMIPLEVEL)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_PREMULTCOLORBYONEOVERMIPLEVEL");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_PREMULTCOLORBYONEOVERMIPLEVEL");
 	if (flags & TEXTUREFLAGS_UNUSED2)
-		ret.push_back("TEXTUREFLAGS_UNUSED2");
+		ret.emplace_back("TEXTUREFLAGS_UNUSED2");
 	if (flags & TEXTUREFLAGS_DEPRECATED_NORMALTODUDV)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_NORMALTODUDV");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_NORMALTODUDV");
 	if (flags & TEXTUREFLAGS_UNUSED3)
-		ret.push_back("TEXTUREFLAGS_UNUSED3");
+		ret.emplace_back("TEXTUREFLAGS_UNUSED3");
 	if (flags & TEXTUREFLAGS_DEPRECATED_ALPHATESTMIPGENERATION)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_ALPHATESTMIPGENERATION");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_ALPHATESTMIPGENERATION");
 	if (flags & TEXTUREFLAGS_NODEPTHBUFFER)
-		ret.push_back("TEXTUREFLAGS_NODEPTHBUFFER");
+		ret.emplace_back("TEXTUREFLAGS_NODEPTHBUFFER");
 	if (flags & TEXTUREFLAGS_UNUSED4)
-		ret.push_back("TEXTUREFLAGS_UNUSED4");
+		ret.emplace_back("TEXTUREFLAGS_UNUSED4");
 	if (flags & TEXTUREFLAGS_DEPRECATED_NICEFILTERED)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_NICEFILTERED");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_NICEFILTERED");
 	if (flags & TEXTUREFLAGS_CLAMPU)
-		ret.push_back("TEXTUREFLAGS_CLAMPU");
+		ret.emplace_back("TEXTUREFLAGS_CLAMPU");
 	if (flags & TEXTUREFLAGS_VERTEXTEXTURE)
-		ret.push_back("TEXTUREFLAGS_VERTEXTEXTURE");
+		ret.emplace_back("TEXTUREFLAGS_VERTEXTEXTURE");
 	if (flags & TEXTUREFLAGS_SSBUMP)
-		ret.push_back("TEXTUREFLAGS_SSBUMP");
+		ret.emplace_back("TEXTUREFLAGS_SSBUMP");
 	if (flags & TEXTUREFLAGS_UNUSED5)
-		ret.push_back("TEXTUREFLAGS_UNUSED5");
+		ret.emplace_back("TEXTUREFLAGS_UNUSED5");
 	if (flags & TEXTUREFLAGS_DEPRECATED_UNFILTERABLE_OK)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_UNFILTERABLE_OK");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_UNFILTERABLE_OK");
 	if (flags & TEXTUREFLAGS_BORDER)
-		ret.push_back("TEXTUREFLAGS_BORDER");
+		ret.emplace_back("TEXTUREFLAGS_BORDER");
 	if (flags & TEXTUREFLAGS_DEPRECATED_SPECVAR_RED)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_SPECVAR_RED");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_SPECVAR_RED");
 	if (flags & TEXTUREFLAGS_DEPRECATED_SPECVAR_ALPHA)
-		ret.push_back("TEXTUREFLAGS_DEPRECATED_SPECVAR_ALPHA");
+		ret.emplace_back("TEXTUREFLAGS_DEPRECATED_SPECVAR_ALPHA");
 
 	return ret;
 }
@@ -189,74 +188,73 @@ const char* GetResourceName(vlUInt resource) {
 VTFImageFormat ImageFormatFromUserString(const char* arg) {
 	if (str::strcasecmp("RGBA8888", arg) == 0)
 		return IMAGE_FORMAT_RGBA8888;
-	else if (str::strcasecmp("ABGR8888", arg) == 0)
+	if (str::strcasecmp("ABGR8888", arg) == 0)
 		return IMAGE_FORMAT_ABGR8888;
-	else if (str::strcasecmp("RGB888", arg) == 0)
+	if (str::strcasecmp("RGB888", arg) == 0)
 		return IMAGE_FORMAT_RGB888;
-	else if (str::strcasecmp("BGR888", arg) == 0)
+	if (str::strcasecmp("BGR888", arg) == 0)
 		return IMAGE_FORMAT_BGR888;
-	else if (str::strcasecmp("RGB565", arg) == 0)
+	if (str::strcasecmp("RGB565", arg) == 0)
 		return IMAGE_FORMAT_RGB565;
-	else if (str::strcasecmp("I8", arg) == 0)
+	if (str::strcasecmp("I8", arg) == 0)
 		return IMAGE_FORMAT_I8;
-	else if (str::strcasecmp("IA88", arg) == 0)
+	if (str::strcasecmp("IA88", arg) == 0)
 		return IMAGE_FORMAT_IA88;
-	else if (str::strcasecmp("P8", arg) == 0)
+	if (str::strcasecmp("P8", arg) == 0)
 		return IMAGE_FORMAT_P8;
-	else if (str::strcasecmp("A8", arg) == 0)
+	if (str::strcasecmp("A8", arg) == 0)
 		return IMAGE_FORMAT_A8;
-	else if (str::strcasecmp("RGB888_BLUESCREEN", arg) == 0)
+	if (str::strcasecmp("RGB888_BLUESCREEN", arg) == 0)
 		return IMAGE_FORMAT_RGB888_BLUESCREEN;
-	else if (str::strcasecmp("BGR888_BLUESCREEN", arg) == 0)
+	if (str::strcasecmp("BGR888_BLUESCREEN", arg) == 0)
 		return IMAGE_FORMAT_BGR888_BLUESCREEN;
-	else if (str::strcasecmp("ARGB8888", arg) == 0)
+	if (str::strcasecmp("ARGB8888", arg) == 0)
 		return IMAGE_FORMAT_ARGB8888;
-	else if (str::strcasecmp("BGRA8888", arg) == 0)
+	if (str::strcasecmp("BGRA8888", arg) == 0)
 		return IMAGE_FORMAT_BGRA8888;
-	else if (str::strcasecmp("DXT1", arg) == 0)
+	if (str::strcasecmp("DXT1", arg) == 0)
 		return IMAGE_FORMAT_DXT1;
-	else if (str::strcasecmp("DXT3", arg) == 0)
+	if (str::strcasecmp("DXT3", arg) == 0)
 		return IMAGE_FORMAT_DXT3;
-	else if (str::strcasecmp("DXT5", arg) == 0)
+	if (str::strcasecmp("DXT5", arg) == 0)
 		return IMAGE_FORMAT_DXT5;
-	else if (str::strcasecmp("BGRX8888", arg) == 0)
+	if (str::strcasecmp("BGRX8888", arg) == 0)
 		return IMAGE_FORMAT_BGRX8888;
-	else if (str::strcasecmp("BGR565", arg) == 0)
+	if (str::strcasecmp("BGR565", arg) == 0)
 		return IMAGE_FORMAT_BGR565;
-	else if (str::strcasecmp("BGRX5551", arg) == 0)
+	if (str::strcasecmp("BGRX5551", arg) == 0)
 		return IMAGE_FORMAT_BGRX5551;
-	else if (str::strcasecmp("BGRA4444", arg) == 0)
+	if (str::strcasecmp("BGRA4444", arg) == 0)
 		return IMAGE_FORMAT_BGRA4444;
-	else if (str::strcasecmp("DXT1_ONEBITALPHA", arg) == 0)
+	if (str::strcasecmp("DXT1_ONEBITALPHA", arg) == 0)
 		return IMAGE_FORMAT_DXT1_ONEBITALPHA;
-	else if (str::strcasecmp("BGRA5551", arg) == 0)
+	if (str::strcasecmp("BGRA5551", arg) == 0)
 		return IMAGE_FORMAT_BGRA5551;
-	else if (str::strcasecmp("UV88", arg) == 0)
+	if (str::strcasecmp("UV88", arg) == 0)
 		return IMAGE_FORMAT_UV88;
-	else if (str::strcasecmp("UVWQ8888", arg) == 0)
+	if (str::strcasecmp("UVWQ8888", arg) == 0)
 		return IMAGE_FORMAT_UVWQ8888;
-	else if (str::strcasecmp("RGBA16161616F", arg) == 0)
+	if (str::strcasecmp("RGBA16161616F", arg) == 0)
 		return IMAGE_FORMAT_RGBA16161616F;
-	else if (str::strcasecmp("RGBA16161616", arg) == 0)
+	if (str::strcasecmp("RGBA16161616", arg) == 0)
 		return IMAGE_FORMAT_RGBA16161616;
-	else if (str::strcasecmp("UVLX8888", arg) == 0)
+	if (str::strcasecmp("UVLX8888", arg) == 0)
 		return IMAGE_FORMAT_UVLX8888;
-	else if (str::strcasecmp("R32F", arg) == 0)
+	if (str::strcasecmp("R32F", arg) == 0)
 		return IMAGE_FORMAT_R32F;
-	else if (str::strcasecmp("RGB323232F", arg) == 0)
+	if (str::strcasecmp("RGB323232F", arg) == 0)
 		return IMAGE_FORMAT_RGB323232F;
-	else if (str::strcasecmp("RGBA32323232F", arg) == 0)
+	if (str::strcasecmp("RGBA32323232F", arg) == 0)
 		return IMAGE_FORMAT_RGBA32323232F;
-	else if (str::strcasecmp("NV_NULL", arg) == 0)
+	if (str::strcasecmp("NV_NULL", arg) == 0)
 		return IMAGE_FORMAT_NV_NULL;
-	else if (str::strcasecmp("ATI2N", arg) == 0)
+	if (str::strcasecmp("ATI2N", arg) == 0)
 		return IMAGE_FORMAT_ATI2N;
-	else if (str::strcasecmp("ATI1N", arg) == 0)
+	if (str::strcasecmp("ATI1N", arg) == 0)
 		return IMAGE_FORMAT_ATI1N;
-	else if (str::strcasecmp("BC7", arg) == 0)
+	if (str::strcasecmp("BC7", arg) == 0)
 		return IMAGE_FORMAT_BC7;
-	else if (str::strcasecmp("COUNT", arg) == 0)
+	if (str::strcasecmp("COUNT", arg) == 0)
 		return IMAGE_FORMAT_COUNT;
-	else
-		return IMAGE_FORMAT_NONE;
+	return IMAGE_FORMAT_NONE;
 }


### PR DESCRIPTION
BC7 is a non-standard Strata exclusive format. Strata is also the only engine that supports VTF v7.6 as far as I can tell. We can tie them together so creating VTFs for an older game using BC7 will give a clear error when the game loads the VTF (because the version is now always v7.6 when creating a VTF with a BC7 format texture).